### PR TITLE
add support where requiredmodules include version numbers

### DIFF
--- a/content/PsAlterModuleVersion/PsAlterModuleVersion.Tests.ps1
+++ b/content/PsAlterModuleVersion/PsAlterModuleVersion.Tests.ps1
@@ -101,4 +101,5 @@ foreach ($testBuildNumber in $VersionNumbers) {
     }
 }
 
+
 Write-Host "Tests passed!" -ForegroundColor Green


### PR DESCRIPTION
PowerShell was updating RequiredModules version numbers. Have included check to only update moduleversion, and not requiredversion. However moduleversion must be above requiredmodules for this to work.